### PR TITLE
feat: add technology badges and update PHP to 8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ The essential foundation - your "SaaS Base" - for building scalable SaaS applica
 
 [![CI](https://github.com/roble/saucebase/actions/workflows/ci.yml/badge.svg)](https://github.com/roble/saucebase/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![PHP Version](https://img.shields.io/badge/PHP-8.4%2B-777BB4?logo=php&logoColor=white)](https://php.net)
+[![Laravel](https://img.shields.io/badge/Laravel-12.0-FF2D20?logo=laravel&logoColor=white)](https://laravel.com)
+[![Vue.js](https://img.shields.io/badge/Vue.js-3.4-4FC08D?logo=vue.js&logoColor=white)](https://vuejs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.8-3178C6?logo=typescript&logoColor=white)](https://typescriptlang.org)
+[![Vite](https://img.shields.io/badge/Vite-6.2-646CFF?logo=vite&logoColor=white)](https://vitejs.dev)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind%20CSS-4.1-06B6D4?logo=tailwind-css&logoColor=white)](https://tailwindcss.com)
+[![Node.js](https://img.shields.io/badge/Node.js-22.0%2B-339933?logo=node.js&logoColor=white)](https://nodejs.org)
+[![Inertia.js](https://img.shields.io/badge/Inertia.js-2.0-9553E9?logo=inertia&logoColor=white)](https://inertiajs.com)
 
 ## Features
 
@@ -21,7 +29,7 @@ The essential foundation - your "SaaS Base" - for building scalable SaaS applica
 
 ### Backend
 - **[Laravel 12](https://laravel.com/docs)** - PHP web framework
-- **[PHP 8.2+](https://www.php.net/docs.php)** - Programming language
+- **[PHP 8.4+](https://www.php.net/docs.php)** - Programming language
 - **[PostgreSQL](https://www.postgresql.org/docs/)** - Database
 - **[Redis](https://redis.io/docs/)** - Caching & session storage
 - **[Laravel Sanctum](https://laravel.com/docs/sanctum)** - API authentication

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.2",
+        "php": "^8.4",
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/horizon": "^5.33",


### PR DESCRIPTION
## Summary

- Add comprehensive technology stack badges to README for better project visibility
- Update PHP minimum requirement from 8.2 to 8.4 in composer.json
- Include badges for PHP, Laravel, Vue.js, TypeScript, Vite, Tailwind CSS, Node.js, and Inertia.js
- Each badge shows version requirements and links to official documentation

## Test plan

- [ ] Verify all badges display correctly in README
- [ ] Confirm PHP 8.4 requirement is enforced during composer install
- [ ] Check that badge links navigate to correct documentation
- [ ] Validate badge colors and logos render properly
- [ ] Test README appearance on GitHub