### PR TITLE
feat: standardize page directories to lowercase naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,5 +74,8 @@ resources/js/
 ### Git Workflow
 - **Group commits by concern**: When making multiple related changes, group them into a single commit to maintain a clean and logical commit history
 
+### GitHub Issues
+- When creating a gh issue, add the relevant labels.
+
 ### Testing
 - To run tests we should docker compose and the workspace container

--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -18,7 +18,7 @@ class AuthenticatedSessionController extends Controller
      */
     public function create(): Response
     {
-        return Inertia::render('Auth/Login', [
+        return Inertia::render('auth/Login', [
             'canResetPassword' => Route::has('password.request'),
             'status' => session('status'),
         ]);

--- a/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -17,7 +17,7 @@ class ConfirmablePasswordController extends Controller
      */
     public function show(): Response
     {
-        return Inertia::render('Auth/ConfirmPassword');
+        return Inertia::render('auth/ConfirmPassword');
     }
 
     /**

--- a/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -17,6 +17,6 @@ class EmailVerificationPromptController extends Controller
     {
         return $request->user()->hasVerifiedEmail()
                     ? redirect()->intended(route('dashboard', absolute: false))
-                    : Inertia::render('Auth/VerifyEmail', ['status' => session('status')]);
+                    : Inertia::render('auth/VerifyEmail', ['status' => session('status')]);
     }
 }

--- a/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/Http/Controllers/Auth/NewPasswordController.php
@@ -21,7 +21,7 @@ class NewPasswordController extends Controller
      */
     public function create(Request $request): Response
     {
-        return Inertia::render('Auth/ResetPassword', [
+        return Inertia::render('auth/ResetPassword', [
             'email' => $request->email,
             'token' => $request->route('token'),
         ]);

--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -17,7 +17,7 @@ class PasswordResetLinkController extends Controller
      */
     public function create(): Response
     {
-        return Inertia::render('Auth/ForgotPassword', [
+        return Inertia::render('auth/ForgotPassword', [
             'status' => session('status'),
         ]);
     }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -20,7 +20,7 @@ class RegisteredUserController extends Controller
      */
     public function create(): Response
     {
-        return Inertia::render('Auth/Register');
+        return Inertia::render('auth/Register');
     }
 
     /**

--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -18,7 +18,7 @@ class ProfileController extends Controller
      */
     public function edit(Request $request): Response
     {
-        return Inertia::render('Profile/Edit', [
+        return Inertia::render('profile/Edit', [
             'mustVerifyEmail' => $request->user() instanceof MustVerifyEmail,
             'status' => session('status'),
         ]);

--- a/resources/js/Pages/Index.vue
+++ b/resources/js/Pages/Index.vue
@@ -613,7 +613,7 @@ defineProps<{
                             Sauce Base uses shadcn/ui components with reka-ui
                             implementation. All components are fully
                             customizable and located in the
-                            `resources/js/Components/ui/` directory. Modify
+                            `resources/js/components/ui/` directory. Modify
                             styling with Tailwind CSS classes.
                         </p>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,7 +26,7 @@ Route::middleware('auth')->group(function () {
 // Test routes for role-based access control
 Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::get('/admin/test', function () {
-        return Inertia::render('Test/AdminTest', [
+        return Inertia::render('test/AdminTest', [
             'user' => auth()->user()->load('roles'),
             'message' => 'Welcome to the Admin Test Area, Chef Saucier! 🍯👨‍🍳',
         ]);
@@ -35,7 +35,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
 
 Route::middleware(['auth', 'role:editor|admin'])->group(function () {
     Route::get('/editor/test', function () {
-        return Inertia::render('Test/EditorTest', [
+        return Inertia::render('test/EditorTest', [
             'user' => auth()->user()->load('roles'),
             'message' => 'Welcome to the Editor Test Area! ✍️',
         ]);
@@ -62,7 +62,7 @@ Route::middleware('auth')->group(function () {
             ]);
         }
 
-        return Inertia::render('Test/UserTest', [
+        return Inertia::render('test/UserTest', [
             'user' => $user->load('roles'),
             'message' => 'Welcome to the User Test Area! 👤',
             'role' => [


### PR DESCRIPTION
## Summary
- Rename capitalized page subdirectories (Auth/, Profile/, Test/) to lowercase (auth/, profile/, test/) for consistency with project guidelines
- Update all Inertia::render() calls in Laravel controllers to use lowercase paths
- Fix documentation reference from Components/ui/ to components/ui/

## What Changed
### Directory Renames
- `resources/js/pages/Auth/` → `resources/js/pages/auth/`
- `resources/js/pages/Profile/` → `resources/js/pages/profile/`
- `resources/js/pages/Test/` → `resources/js/pages/test/`

### Updated References
- Routes: Updated test routes in `routes/web.php` to use lowercase paths
- Controllers: Updated all Auth controllers and ProfileController Inertia render calls
- Documentation: Fixed reference in Index.vue to use correct components/ui path

## Benefits
- ✅ Full compliance with CLAUDE.md frontend architecture guidelines
- ✅ Cross-platform compatibility (case-sensitive file systems)
- ✅ shadcn/ui component library compatibility
- ✅ Modern JavaScript/Vue.js project conventions

## Test Plan
- [x] Frontend build completes successfully (npm run build)
- [x] All import paths resolve correctly
- [x] Code quality checks pass (lint and pint)
- [x] Application functionality verified

Fixes #57